### PR TITLE
Optimize camera reference caching and improve encapsulation by using [SerializeField] private

### DIFF
--- a/Assets/Scripts/CursorController.cs
+++ b/Assets/Scripts/CursorController.cs
@@ -6,11 +6,20 @@ using UnityEngine.Tilemaps;
 
 public partial class CursorController : MonoBehaviour {
     public DualGridTilemap dualGridTilemap;
+
+    private Vector3 offset = new Vector3(0.5f, 0.5f, -1);
+    private Camera mainCamera;
+
+    void Awake() {
+        mainCamera = Camera.main;
+    }
+        
+    
     void Update() {
-        var mouseWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        var mouseWorldPos = mainCamera.ScreenToWorldPoint(Input.mousePosition);
 
         Vector3Int tilePos = GetWorldPosTile(mouseWorldPos);
-        transform.position = tilePos + new Vector3(0.5f, 0.5f, -1);
+        transform.position = tilePos + offset;
 
         if (Input.GetMouseButton(0)) {
             dualGridTilemap.SetCell(tilePos, dualGridTilemap.dirtPlaceholderTile);

--- a/Assets/Scripts/CursorController.cs
+++ b/Assets/Scripts/CursorController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEngine.Tilemaps;
 
 public partial class CursorController : MonoBehaviour {
-    public DualGridTilemap dualGridTilemap;
+    [SerializeField] private DualGridTilemap dualGridTilemap;
 
     private Vector3 offset = new Vector3(0.5f, 0.5f, -1);
     private Camera mainCamera;
@@ -13,7 +13,6 @@ public partial class CursorController : MonoBehaviour {
     void Awake() {
         mainCamera = Camera.main;
     }
-        
     
     void Update() {
         var mouseWorldPos = mainCamera.ScreenToWorldPoint(Input.mousePosition);

--- a/Assets/Scripts/DualGridTilemap.cs
+++ b/Assets/Scripts/DualGridTilemap.cs
@@ -16,15 +16,15 @@ public class DualGridTilemap : MonoBehaviour {
     protected static Dictionary<Tuple<TileType, TileType, TileType, TileType>, Tile> neighbourTupleToTile;
 
     // Provide references to each tilemap in the inspector
-    public Tilemap placeholderTilemap;
-    public Tilemap displayTilemap;
+    [SerializeField] private Tilemap placeholderTilemap;
+    [SerializeField] private Tilemap displayTilemap;
 
     // Provide the dirt and grass placeholder tiles in the inspector
     public Tile grassPlaceholderTile;
     public Tile dirtPlaceholderTile;
 
     // Provide the 16 tiles in the inspector
-    public Tile[] tiles;
+    [SerializeField] private Tile[] tiles;
 
     void Start() {
         // This dictionary stores the "rules", each 4-neighbour configuration corresponds to a tile


### PR DESCRIPTION
- Caching the camera reduces the load on the system, since Camera.main is a costly call;
- using [SerializeField] private instead of public helps to avoid unwanted access to fields from other classes, which increases the reliability and maintainability of the code.